### PR TITLE
[failed] make `GroupSpec` a mutable mapping

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -55,7 +55,7 @@ print(spec.dict())
 spec2 = spec.copy()
 spec2.attrs = {'a': 100, 'b': 'metadata'}
 
-spec2.items['bar'].shape = (100,)
+spec2['bar'].shape = (100,)
 
 # serialize the spec to the store
 group2 = spec2.to_zarr(grp.store, path='foo2')
@@ -151,17 +151,17 @@ except ValidationError as exc:
     """
 
 # this passes validation
-items = {'foo': ArraySpec(attrs={}, 
+content = {'foo': ArraySpec(attrs={}, 
                           shape=(1,), 
                           dtype='uint8', 
                           chunks=(1,), 
                           compressor=None)}
-print(ArraysOnlyGroup(attrs={}, items=items).dict())
+print(ArraysOnlyGroup(attrs={}, content=content).dict())
 """
 {
     'zarr_version': 2,
     'attrs': {},
-    'items': {
+    'content': {
         'foo': {
             'zarr_version': 2,
             'attrs': {},

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,15 @@ import numpy as np
 import numpy.typing as npt
 
 
+def test_group_spec():
+    root = GroupSpec(attrs={}, content={})
+    subgroup = GroupSpec(attrs={"foo": 100})
+    assert len(root) == len(root.content) == 0
+    root["subgroup"] = subgroup
+    assert root["subgroup"] == subgroup
+    assert len(root) == 1
+
+
 @pytest.mark.parametrize("chunks", ((1,), (1, 2), ((1, 2, 3))))
 @pytest.mark.parametrize("order", ("C", "F"))
 @pytest.mark.parametrize("dtype", ("bool", "uint8", "float64"))
@@ -157,7 +166,7 @@ def test_serde(
 
     spec = GroupSpec(
         attrs=RootAttrs(foo=10, bar=[0, 1, 2]),
-        items={
+        content={
             "s0": ArraySpec(
                 shape=(10,) * len(chunks),
                 chunks=chunks,
@@ -226,7 +235,7 @@ def test_validation():
 
     specA = GroupA(
         attrs=GroupAttrsA(group_a=True),
-        items={
+        content={
             "a": ArrayA(
                 attrs=ArrayAttrsA(array_a=True),
                 shape=(100,),
@@ -238,7 +247,7 @@ def test_validation():
 
     specB = GroupB(
         attrs=GroupAttrsB(group_b=True),
-        items={
+        content={
             "a": ArrayB(
                 attrs=ArrayAttrsB(array_b=True),
                 shape=(100,),


### PR DESCRIPTION
This was an effort to make `GroupSpec` inherit from `MutableMapping` in order to expose the subgroups / subarrays
 of `GroupSpec` via `__getitem__`. 

It failed for two reasons: 
- `GroupSpec.dict()` started including some private variable named `__orig_class__`, which broke serializing to zarr
- The semantics of a `MutableMapping` are ambiguous for `GroupSpec` (and perhaps, by extension, a zarr group). If `attrs` is a dict, then both `GroupSpec.attrs` _and_ `GroupSpec.items` have values that can be accessed with the `MutableMapping` interface. it doesn't make sense to blend the namespaces of the two, and it seems unfair to pick one over the other as the target for GroupSpec['blablabla'].

This PR will live here as an example of something that didn't work. Don't merge it.