### PR TITLE
groupspec from zarr fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic-zarr"
-version = "0.4.0"
+version = "0.5.0"
 description = "pydantic models for zarr"
 authors = ["Davis Vann Bennett <davis.v.bennett@gmail.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic-zarr"
-version = "0.5.0"
+version = "0.4.0"
 description = "pydantic models for zarr"
 authors = ["Davis Vann Bennett <davis.v.bennett@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
- release: version bump
- chore: add overloaded type annotation and change some instances of dict(attrs) to attrs.asdict()
