### PR TITLE
Fix from_zarr for arrays with no dimension names

### DIFF
--- a/src/pydantic_zarr/v3.py
+++ b/src/pydantic_zarr/v3.py
@@ -1046,7 +1046,10 @@ def auto_storage_transformers(data: object) -> tuple[AnyNamedConfig, ...]:
 
 def auto_dimension_names(data: object) -> tuple[str | None, ...] | None:
     if hasattr(data, "metadata") and hasattr(data.metadata, "dimension_names"):
-        return tuple(data.metadata.dimension_names)
+        if data.metadata.dimension_names is None:
+            return None
+        else:
+            return tuple(data.metadata.dimension_names)
     return None
 
 

--- a/tests/test_pydantic_zarr/test_v3.py
+++ b/tests/test_pydantic_zarr/test_v3.py
@@ -252,7 +252,13 @@ def test_mix_v3_v2_fails() -> None:
         GroupSpec.from_flat(members_flat)  # type: ignore[arg-type]
 
 
-def test_dim_names_from_zarr_array() -> None:
-    arr = zarr.zeros((1,), dimension_names=["x"])
-    spec = ArraySpec.from_zarr(arr)
-    assert spec.dimension_names == ("x",)
+@pytest.mark.parametrize(
+    ("arr", "expected_names"),
+    [
+        (zarr.zeros((1,), dimension_names=["x"]), ("x",)),
+        (zarr.zeros((1,)), None),
+    ],
+)
+def test_dim_names_from_zarr_array(arr: zarr.Array, expected_names: tuple[str, ...] | None) -> None:
+    spec: AnyArraySpec = ArraySpec.from_zarr(arr)
+    assert spec.dimension_names == expected_names


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/pydantic-zarr/issues/107
