### PR TITLE
Remove default empty dictionary for attributes in ArraySpec and GroupSpec

### DIFF
--- a/docs/usage_zarr_v2.md
+++ b/docs/usage_zarr_v2.md
@@ -122,7 +122,7 @@ from pydantic_zarr.v2 import ArraySpec, GroupSpec
 tree = {
     "": GroupSpec(members=None, attributes={"root": True}),
     "/a": GroupSpec(members=None, attributes={"root": False}),
-    "/a/b": ArraySpec(shape=(10, 10), dtype="uint8", chunks=(1, 1)),
+    "/a/b": ArraySpec(shape=(10, 10), dtype="uint8", chunks=(1, 1), attributes={}),
 }
 
 print(GroupSpec.from_flat(tree).model_dump())
@@ -166,7 +166,7 @@ from pydantic_zarr.v2 import ArraySpec, GroupSpec
 # the keys must be valid paths in the Zarr storage hierarchy
 # note that the `members` attribute is `None` for the `GroupSpec` instances in this `dict`.
 
-a_b = ArraySpec(shape=(10, 10), dtype="uint8", chunks=(1, 1))
+a_b = ArraySpec(shape=(10, 10), dtype="uint8", chunks=(1, 1), attributes={})
 a = GroupSpec(members={'b': a_b}, attributes={"root": False})
 root = GroupSpec(members={'a': a}, attributes={"root": True})
 
@@ -200,7 +200,7 @@ hierarchy without explicitly creating the intermediate groups first.
 ```python
 from pydantic_zarr.v2 import ArraySpec, GroupSpec
 
-tree = {'/a/b/c': ArraySpec(shape=(1,), dtype='uint8', chunks=(1,))}
+tree = {'/a/b/c': ArraySpec(shape=(1,), dtype='uint8', chunks=(1,), attributes={})}
 print(GroupSpec.from_flat(tree).model_dump())
 """
 {
@@ -250,9 +250,9 @@ import zarr.storage
 
 from pydantic_zarr.v2 import ArraySpec, GroupSpec
 
-arr_a = ArraySpec(shape=(1,), dtype='uint8', chunks=(1,))
+arr_a = ArraySpec(shape=(1,), dtype='uint8', chunks=(1,), attributes={})
 # make an array with a different shape
-arr_b = ArraySpec(shape=(2,), dtype='uint8', chunks=(1,))
+arr_b = ArraySpec(shape=(2,), dtype='uint8', chunks=(1,), attributes={})
 
 # Returns False, because of mismatched shape
 print(arr_a.like(arr_b))

--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -143,7 +143,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
 
     Attributes
     ----------
-    attributes: TAttr, default = {}
+    attributes: TAttr
         User-defined metadata associated with this array. Should be JSON-serializable.
     shape: tuple[int, ...]
         The shape of this array.
@@ -168,7 +168,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         The default is "/".
     """
 
-    attributes: TAttr = cast(TAttr, {})
+    attributes: TAttr
     shape: tuple[int, ...]
     chunks: tuple[int, ...]
     dtype: DtypeStr | list[tuple[Any, ...]]
@@ -467,7 +467,7 @@ class GroupSpec(NodeSpec, Generic[TAttr, TItem]):
     Attributes
     ----------
 
-    attributes: TAttr, default = {}
+    attributes: TAttr
         The user-defined attributes of this group. Should be JSON-serializable.
     members: dict[str, TItem] | None, default = {}
         The members of this group. `members` may be `None`, which models the condition
@@ -476,7 +476,7 @@ class GroupSpec(NodeSpec, Generic[TAttr, TItem]):
         are either `ArraySpec` or `GroupSpec`.
     """
 
-    attributes: TAttr = cast(TAttr, {})
+    attributes: TAttr
     members: Annotated[Mapping[str, TItem] | None, AfterValidator(ensure_key_no_path)] = {}
 
     @classmethod

--- a/src/pydantic_zarr/v3.py
+++ b/src/pydantic_zarr/v3.py
@@ -201,7 +201,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
     """
 
     node_type: Literal["array"] = "array"
-    attributes: TAttr = cast(TAttr, {})
+    attributes: TAttr
     shape: tuple[int, ...]
     data_type: DTypeLike
     chunk_grid: RegularChunking  # todo: validate this against shape
@@ -507,7 +507,7 @@ class GroupSpec(NodeSpec, Generic[TAttr, TItem]):
     """
 
     node_type: Literal["group"] = "group"
-    attributes: TAttr = cast("TAttr", {})
+    attributes: TAttr
     members: Annotated[Mapping[str, TItem] | None, AfterValidator(ensure_key_no_path)] = {}
 
     @classmethod

--- a/tests/test_pydantic_zarr/test_v2.py
+++ b/tests/test_pydantic_zarr/test_v2.py
@@ -576,7 +576,7 @@ def test_array_like() -> None:
 
 
 def test_array_like_with_zarr() -> None:
-    arr = ArraySpec(shape=(1,), dtype="uint8", chunks=(1,))
+    arr = ArraySpec(shape=(1,), dtype="uint8", chunks=(1,), attributes={})
     store = zarr.storage.MemoryStore()
     arr_stored = arr.to_zarr(store, path="arr")
     assert arr.like(arr_stored)

--- a/tests/test_pydantic_zarr/test_v3.py
+++ b/tests/test_pydantic_zarr/test_v3.py
@@ -142,6 +142,7 @@ def test_arrayspec_to_zarr(
     store = {}
 
     arr_spec = ArraySpec(
+        attributes={},
         shape=(10,),
         data_type=data_type,
         chunk_grid={"name": "regular", "configuration": {"chunk_shape": (10,)}},


### PR DESCRIPTION
Fixes #114 

this is what it looks like with having no default value.  @d-v-b ... let me know if you prefer using `validate_defaults=True` instead after seeing this