### PR TITLE
Add packaging to deps (fix broken import on bare install)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,3 +71,16 @@ jobs:
     - name: Run Tests
       run: |
         hatch run docs:test
+
+  test-min-reqs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+    - name: Install minimum requirements
+      run: |
+        pip install .
+        python -c "import pydantic_zarr.v2; import pydantic_zarr.v3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
-dependencies = ["pydantic>2.0.0", "numpy>=1.24.0"]
+dependencies = ["pydantic>2.0.0", "numpy>=1.24.0", "packaging>=21.0"]
+
 [project.urls]
 Documentation = "https://pydantic-zarr.readthedocs.io/"
 Issues = "https://github.com/zarr-developers/pydantic-zarr/issues"


### PR DESCRIPTION
While looking at #120, I realized there's an implicit dependency on `packaging` (which was probably an "accidental" transitive dependency of the previous direct zarr dependence ... similar to the issue with https://github.com/zarr-developers/zarr-python/issues/3592)

This PR does the bare minimal thing of adding packaging, and adding a simple test to just make sure the package can be imported after pip install ... but it could be made more elaborate by:
- adding a test to the CI matrix that tests with only the state dependencies (omitting all the optional dependencies)... but this would also mean adding pytest.skip to all tests that required optional dependencies.
- dropping the dependency on packaging altogether which (I think?) is just being used for simple version parsing...
- 