### PR TITLE
add a special breaking changes header to the 0.9.0 release notes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,7 +17,8 @@ This release contains breaking changes. See [Bugfixes](#090-bugfixes)
 
 - Remove default empty dictionary for attributes in ArraySpec and GroupSpec. This is a breaking change.
 To migrate your code, provide a value for the `attributes` argument when creating an `ArraySpec` or
-`GroupSpec`. ([#115](https://github.com/zarr-developers/pydantic-zarr/issues/115))
+`GroupSpec`. ([#115](https://github.com/zarr-developers/pydantic-zarr/issues/115)).
+To replicate the previous default behaviour, pass an empty dictionary (`attributes={}`).
 - Fix a broken bare install by making the dependency on `packaging` explicit. ([#125](https://github.com/zarr-developers/pydantic-zarr/issues/125))
 
 ### Improved Documentation


### PR DESCRIPTION
adds a special header heralding the breaking changes in this release. To make the internal links stable across releases, we need to declare a specific ID for the header in question, which is why there's some extra raw HTML in here.