### PR TITLE
Split the build/upload process in GH actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
             python-version: "3.x"
         - name: Install Hatch
           run: |
-            pip install hatch==1.14.1
+            pip install hatch==1.16.5
         - name: Build package
           run: |
             hatch build

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: Build and publish Python 🐍 distributions 📦 to PyPI
 on: push
 
 jobs:
-    build-n-publish:
+    build:
       name: Build and publish Python 🐍 distributions 📦 to PyPI
       runs-on: ubuntu-latest
       if:
@@ -20,7 +20,27 @@ jobs:
         - name: Build package
           run: |
             hatch build
-        - name: Publish distribution 📦 to PyPI
-          uses: pypa/gh-action-pypi-publish@release/v1
+        - name: Store the distribution packages
+          uses: actions/upload-artifact@v5
           with:
-            password: ${{ secrets.PYPI_API_TOKEN }}
+            name: python-package-distributions
+            path: dist/
+
+    publish-to-pypi:
+      name: >-
+        Publish Python 🐍 distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+      needs:
+        - build
+      runs-on: ubuntu-latest
+
+      steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v6
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,11 @@
 name: Build and publish Python 🐍 distributions 📦 to PyPI
 
-on: push
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
     build:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,8 +6,6 @@ jobs:
     build:
       name: Build and publish Python 🐍 distributions 📦 to PyPI
       runs-on: ubuntu-latest
-      if:
-        startsWith(github.ref, 'refs/tags')
       steps:
         - uses: actions/checkout@v6
         - name: Set up Python


### PR DESCRIPTION
Pacakge building is broken because of https://github.com/pypa/hatch/issues/2193 😭. Before fixing (by bumping the hatch version), I'm going to try splitting the build/publish jobs so build is run on every PR/main commit and therefore issues like this can be spotted before a release.