### PR TITLE
Alter cd.yml to use OIDC tokens.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,8 +11,6 @@ jobs:
     build:
       name: Build and publish Python 🐍 distributions 📦 to PyPI
       runs-on: ubuntu-latest
-      if:
-        startsWith(github.ref, 'refs/tags')
       steps:
         - uses: actions/checkout@v6
         - name: Set up Python

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,9 @@ jobs:
       runs-on: ubuntu-latest
       if:
         startsWith(github.ref, 'refs/tags')
+      environment: release
+      permissions:
+        id-token: write
       steps:
         - uses: actions/checkout@v6
         - name: Set up Python
@@ -22,5 +25,3 @@ jobs:
             hatch build
         - name: Publish distribution 📦 to PyPI
           uses: pypa/gh-action-pypi-publish@release/v1
-          with:
-            password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Instead of using pypi creds directly, this will avoid the need to storing secrets on github.