### PR TITLE
Add dev dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ test = [
 docs = [
     "pydantic_zarr[docs]"
 ]
+dev = [
+    "pydantic-zarr[test]",
+]
 
 [tool.hatch]
 version.source = "vcs"


### PR DESCRIPTION
This is a minor improvement to using `uv` to develop. By default `uv sync` will also include the 'dev' group, so include that group so it's a bit quicker to get up and running with testing.