### PR TITLE
ci: add zizmor, harden workflows, tighten release tag rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,14 +7,20 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
     build:
       name: Build and publish Python 🐍 distributions 📦 to PyPI
       runs-on: ubuntu-latest
+      permissions:
+        contents: read
       steps:
-        - uses: actions/checkout@v6
+        - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+          with:
+            persist-credentials: false
         - name: Set up Python
-          uses: actions/setup-python@v6
+          uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
           with:
             python-version: "3.x"
         - name: Install Hatch
@@ -24,7 +30,7 @@ jobs:
           run: |
             hatch build
         - name: Store the distribution packages
-          uses: actions/upload-artifact@v5
+          uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
           with:
             name: python-package-distributions
             path: dist/
@@ -36,14 +42,17 @@ jobs:
       needs:
         - build
       runs-on: ubuntu-latest
+      environment:
+        name: release
+        url: https://pypi.org/p/pydantic-zarr
+      permissions:
+        id-token: write  # IMPORTANT: mandatory for trusted publishing
 
       steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: python-package-distributions
           path: dist/
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0

--- a/.github/workflows/check_changelogs.yml
+++ b/.github/workflows/check_changelogs.yml
@@ -3,16 +3,22 @@ name: Check changelog entries
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   check-changelogs:
     name: Check changelog entries
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Check changelog entries
         run: uv run --no-sync python ci/check_changelog_entries.py

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,10 +5,16 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-      - uses: pre-commit/action@v3.0.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,6 +19,9 @@ concurrency:
 jobs:
   test:
     name: os=${{ matrix.os }}, py=${{ matrix.python-version }}, zarr-python=${{ matrix.zarr-version }}
+
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -26,9 +31,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -47,7 +54,7 @@ jobs:
         hatch run test-base.py${{ matrix.python-version }}:list-env
         hatch run test-base.py${{ matrix.python-version }}:test-cov
     - name: Upload coverage
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true # optional (default = false)
@@ -55,12 +62,15 @@ jobs:
   doctests:
     name: doctests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0 # required for hatch version discovery, which is needed for numcodecs.zarr3
+        persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
         cache: 'pip'
@@ -74,10 +84,14 @@ jobs:
 
   test-min-reqs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
     - name: Install minimum requirements

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,7 @@ repos:
     rev: v1.8.0
     hooks:
       - id: numpydoc-validation
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.25.2
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
Add the zizmor pre-commit hook (zizmorcore/zizmor-pre-commit@v1.25.2) to
audit GitHub Actions workflows for security issues, and resolve every
finding it raised:

- SHA-pin all actions across all workflows, with version comments so
  dependabot can still track and bump them (unpinned-uses)
- Add deny-all top-level `permissions: {}` plus least-privilege
  per-job grants (excessive-permissions)
- Set `persist-credentials: false` on all checkouts (artipacked)
- Add a 7-day dependabot cooldown (dependabot-cooldown)
- Publish to PyPI via OIDC trusted publishing only: drop the
  PYPI_API_TOKEN password and add `id-token: write`
  (use-trusted-publishing)
- Bind the publish job to the `release` environment

The `release` environment's deployment rule is also tightened to only
allow tags matching v[0-9]*.[0-9]*.[0-9]* (configured on GitHub).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
