### PR TITLE
Support v2 chunk key encoding in experimental v3 module

### DIFF
--- a/changes/166.feature.md
+++ b/changes/166.feature.md
@@ -1,0 +1,1 @@
+Added support for the v2 chunk key encoding (`{"name": "v2", "configuration": {"separator": ...}}`) in the experimental `pydantic_zarr.experimental.v3` module, so experimental `ArraySpec` can model and round-trip Zarr v3 arrays that use it.

--- a/src/pydantic_zarr/experimental/v3.py
+++ b/src/pydantic_zarr/experimental/v3.py
@@ -107,6 +107,13 @@ class DefaultChunkKeyEncodingConfig(TypedDict):
 DefaultChunkKeyEncoding = NamedConfig[Literal["default"], DefaultChunkKeyEncodingConfig]
 
 
+class V2ChunkKeyEncodingConfig(TypedDict):
+    separator: Literal[".", "/"]
+
+
+V2ChunkKeyEncoding = NamedConfig[Literal["v2"], V2ChunkKeyEncodingConfig]
+
+
 class AllowedExtraField(TypedDict):
     """
     The type of additional fields that may be added to Zarr V3 Array or Group metadata documents.
@@ -226,7 +233,9 @@ class ArraySpec(NodeSpec):
     shape: tuple[int, ...]
     data_type: DTypeLike
     chunk_grid: RegularChunking  # todo: validate this against shape
-    chunk_key_encoding: DefaultChunkKeyEncoding  # todo: validate this against shape
+    chunk_key_encoding: (
+        DefaultChunkKeyEncoding | V2ChunkKeyEncoding
+    )  # todo: validate this against shape
     fill_value: FillValue  # todo: validate this against the data type
     codecs: CodecTuple
     storage_transformers: tuple[AnyNamedConfig, ...] = ()

--- a/tests/test_pydantic_zarr/test_experimental/test_v3.py
+++ b/tests/test_pydantic_zarr/test_experimental/test_v3.py
@@ -16,6 +16,7 @@ from pydantic_zarr.experimental.v3 import (
     DefaultChunkKeyEncoding,
     DefaultChunkKeyEncodingConfig,
     GroupSpec,
+    NamedConfig,
     RegularChunking,
     RegularChunkingConfig,
     auto_codecs,
@@ -476,3 +477,47 @@ def test_consolidated_metadata_to_from_zarr() -> None:
     store2: dict[str, object] = {}
     gspec.to_zarr(store2, path="")
     assert json.loads(store["zarr.json"].to_bytes()) == json.loads(store2["zarr.json"].to_bytes())
+
+
+def test_v2_chunk_key_encoding() -> None:
+    # Simple smoke test to make sure v2 chunk key encoding is allowed
+    ArraySpec(
+        attributes={},
+        shape=[1000, 1000],
+        dimension_names=["rows", "columns"],
+        data_type="float64",
+        chunk_grid=NamedConfig(name="regular", configuration={"chunk_shape": [1000, 100]}),
+        chunk_key_encoding=NamedConfig(name="v2", configuration={"separator": "."}),
+        codecs=[NamedConfig(name="GZip", configuration={"level": 1})],
+        fill_value="NaN",
+        storage_transformers=[],
+    )
+
+
+@pytest.mark.parametrize("separator", [".", "/"])
+def test_v2_chunk_key_encoding_round_trip(separator: str) -> None:
+    """
+    Test that a zarr v3 array with a v2 chunk key encoding can be round-tripped through
+    ArraySpec: from_zarr then to_zarr should yield structurally identical metadata.
+    """
+    zarr = pytest.importorskip("zarr")
+    store: dict[str, object] = {}
+    arr = zarr.create_array(
+        store=store,
+        shape=(10,),
+        dtype="float64",
+        zarr_format=3,
+        chunk_key_encoding={"name": "v2", "configuration": {"separator": separator}},
+    )
+
+    spec = ArraySpec.from_zarr(arr)
+    assert spec.chunk_key_encoding == {
+        "name": "v2",
+        "configuration": {"separator": separator},
+    }
+
+    store_out: dict[str, object] = {}
+    spec.to_zarr(store_out, path="")
+    assert json.loads(store["zarr.json"].to_bytes()) == json.loads(
+        store_out["zarr.json"].to_bytes()
+    )


### PR DESCRIPTION
## Summary

Ports the `V2ChunkKeyEncoding` feature from the stable `v3` module into the experimental `v3` module, as part of the review in #165.

The stable module gained support for the Zarr v3 `{"name": "v2", "configuration": {"separator": ...}}` chunk key encoding in #148 (commit 236f845). The experimental module (`src/pydantic_zarr/experimental/v3.py`) missed this: its `ArraySpec.chunk_key_encoding` field only accepted `DefaultChunkKeyEncoding`, so an experimental `ArraySpec` could not model or round-trip Zarr v3 arrays using the v2 chunk key encoding.

## Changes

- Add `V2ChunkKeyEncodingConfig` and `V2ChunkKeyEncoding` to the experimental v3 module.
- Widen `ArraySpec.chunk_key_encoding` to `DefaultChunkKeyEncoding | V2ChunkKeyEncoding`, mirroring stable.
- Port the smoke test from #148 into the experimental test suite, plus a `from_zarr` -> `to_zarr` round-trip test that exercises both `.` and `/` separators against zarr-python.

Unlike the stable module — which has a known wart where `V2ChunkKeyEncoding` reuses `DefaultChunkKeyEncodingConfig` — this implementation parametrizes `V2ChunkKeyEncoding` with its own `V2ChunkKeyEncodingConfig`.

Refs #165, #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)